### PR TITLE
Set up a repository field so that npm recognises it

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "tape test/*.test.js"
   },
-  "repository": "github:tuananh/package-json-editor",
+  "repository": "https://github.com/tuananh/package-json-editor",
   "author": "Tuan Anh Tran <me@tuananh.org> (https://tuananh.org)",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Currently npm doesn't recognise the repository field, see right sidebar on https://www.npmjs.com/package/package-json-editor — "repository" is blank. It's because of the wrong format in package.json "repository" key's value. This change should fix it.